### PR TITLE
fixed hiredis dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nagios-redis",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Nagios plugin to monitor redis status",
   "main": "check_redis.js",
   "bin": {
@@ -14,7 +14,7 @@
   "license": "none",
   "dependencies": {
     "bytes": "^2.1.0",
-    "hiredis": "^0.3.0",
+    "hiredis": ">=0.5.0",
     "optimist": "^0.6.1",
     "redis": "^0.12.1"
   },


### PR DESCRIPTION
hiredis now requires 0.4.0 or greater. This package does not install otherwise